### PR TITLE
Fix tokenizer test parameter

### DIFF
--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -5,7 +5,7 @@ from whisper.tokenizer import get_tokenizer
 
 @pytest.mark.parametrize("multilingual", [True, False])
 def test_tokenizer(multilingual):
-    tokenizer = get_tokenizer(multilingual=False)
+    tokenizer = get_tokenizer(multilingual=multilingual)
     assert tokenizer.sot in tokenizer.sot_sequence
     assert len(tokenizer.all_language_codes) == len(tokenizer.all_language_tokens)
     assert all(c < tokenizer.timestamp_begin for c in tokenizer.all_language_tokens)


### PR DESCRIPTION
## Summary
- ensure `test_tokenizer` actually uses the parametrized `multilingual` argument

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68456b2b1624832fac2d98b2c884aff8