### PR TITLE
Add SAPCO subscription platform docs and sample code

### DIFF
--- a/SAPCO/README.md
+++ b/SAPCO/README.md
@@ -1,0 +1,11 @@
+# SAPCO Subscription Platform
+
+This directory contains implementation notes, code samples, and content for a proposed subscription website for **School Administrators Publishing Company** (SAPCO).
+
+Folders:
+- `docs/` – planning documents and SEO copy.
+- `frontend/` – sample HTML/CSS/JS for user-facing pages.
+- `backend/` – Node.js sample code snippets for authentication, billing, watermarking, and audit logs.
+- `database/` – schema definitions for PostgreSQL.
+
+Refer to the files in `docs/` for detailed instructions and descriptions.

--- a/SAPCO/backend/README.md
+++ b/SAPCO/backend/README.md
@@ -1,0 +1,1 @@
+Sample Node.js backend demonstrating authentication, billing integration with Stripe, 3D watermarking via pdf-lib, and audit logging.

--- a/SAPCO/backend/models/auditLog.js
+++ b/SAPCO/backend/models/auditLog.js
@@ -1,0 +1,6 @@
+const logs = [];
+
+module.exports.record = async function(userId, action) {
+  logs.push({ userId, action, at: new Date() });
+  console.log('AUDIT', userId, action);
+};

--- a/SAPCO/backend/models/user.js
+++ b/SAPCO/backend/models/user.js
@@ -1,0 +1,8 @@
+// Placeholder user model using in-memory users for demo
+const users = [
+  { id: 1, email: 'admin@example.com', password_hash: '$2b$10$hash', role: 'admin' }
+];
+
+module.exports.findByEmail = async function(email) {
+  return users.find(u => u.email === email);
+};

--- a/SAPCO/backend/routes/auth.js
+++ b/SAPCO/backend/routes/auth.js
@@ -1,0 +1,17 @@
+const router = require('express').Router();
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcrypt');
+const User = require('../models/user');
+
+// POST /api/auth/login
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  const user = await User.findByEmail(email);
+  if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+  const valid = await bcrypt.compare(password, user.password_hash);
+  if (!valid) return res.status(401).json({ message: 'Invalid credentials' });
+  const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET, { expiresIn: '1h' });
+  res.json({ token });
+});
+
+module.exports = router;

--- a/SAPCO/backend/routes/billing.js
+++ b/SAPCO/backend/routes/billing.js
@@ -1,0 +1,17 @@
+const router = require('express').Router();
+const stripe = require('stripe')(process.env.STRIPE_SECRET);
+
+// POST /api/billing/checkout
+router.post('/checkout', async (req, res) => {
+  const { priceId } = req.body;
+  const session = await stripe.checkout.sessions.create({
+    payment_method_types: ['card'],
+    mode: 'subscription',
+    line_items: [{ price: priceId, quantity: 1 }],
+    success_url: process.env.DOMAIN + '/success',
+    cancel_url: process.env.DOMAIN + '/cancel'
+  });
+  res.json({ url: session.url });
+});
+
+module.exports = router;

--- a/SAPCO/backend/routes/forms.js
+++ b/SAPCO/backend/routes/forms.js
@@ -1,0 +1,21 @@
+const router = require('express').Router();
+const { requireRole } = require('../utils/auth-middleware');
+const pdfLib = require('pdf-lib');
+const fs = require('fs');
+const AuditLog = require('../models/auditLog');
+
+// GET /api/forms/:id/download
+router.get('/:id/download', requireRole('admin'), async (req, res) => {
+  const pdfBytes = fs.readFileSync('path/to/template.pdf');
+  const pdfDoc = await pdfLib.PDFDocument.load(pdfBytes);
+  const watermark = await pdfDoc.embedText(`User: ${req.user.id}  Time: ${new Date().toISOString()}`);
+  const pages = pdfDoc.getPages();
+  pages[0].drawText('SAPCO', { x: 50, y: 50, size: 12, font: watermark });
+  const output = await pdfDoc.save();
+
+  await AuditLog.record(req.user.id, `download form ${req.params.id}`);
+  res.setHeader('Content-Type', 'application/pdf');
+  res.send(output);
+});
+
+module.exports = router;

--- a/SAPCO/backend/server.js
+++ b/SAPCO/backend/server.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const app = express();
+const authRoutes = require('./routes/auth');
+const billingRoutes = require('./routes/billing');
+const formsRoutes = require('./routes/forms');
+const helmet = require('helmet');
+const morgan = require('morgan');
+
+app.use(express.json());
+app.use(helmet());
+app.use(morgan('combined'));
+
+app.use('/api/auth', authRoutes);
+app.use('/api/billing', billingRoutes);
+app.use('/api/forms', formsRoutes);
+
+app.listen(3000, () => console.log('Server running on port 3000'));

--- a/SAPCO/backend/utils/auth-middleware.js
+++ b/SAPCO/backend/utils/auth-middleware.js
@@ -1,0 +1,19 @@
+const jwt = require('jsonwebtoken');
+
+function requireRole(role) {
+  return (req, res, next) => {
+    const auth = req.headers.authorization;
+    if (!auth) return res.status(401).end();
+    try {
+      const token = auth.split(' ')[1];
+      const payload = jwt.verify(token, process.env.JWT_SECRET);
+      if (payload.role !== role) return res.status(403).end();
+      req.user = payload;
+      next();
+    } catch (err) {
+      return res.status(401).end();
+    }
+  };
+}
+
+module.exports = { requireRole };

--- a/SAPCO/database/schema.sql
+++ b/SAPCO/database/schema.sql
@@ -1,0 +1,37 @@
+-- PostgreSQL schema for SAPCO
+
+CREATE TABLE roles (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  password_hash TEXT NOT NULL,
+  role_id INTEGER REFERENCES roles(id),
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE forms (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  template_path TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE subscriptions (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id),
+  stripe_subscription_id TEXT,
+  tier TEXT,
+  active BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE audit_logs (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id),
+  action TEXT,
+  at TIMESTAMP DEFAULT NOW()
+);

--- a/SAPCO/docs/deployment_instructions.md
+++ b/SAPCO/docs/deployment_instructions.md
@@ -1,0 +1,30 @@
+# Deployment, SSL, Backup & Monitoring Guide
+
+## 1. AWS Infrastructure
+1. **VPC & Subnets** – Create a dedicated VPC with public and private subnets.
+2. **RDS PostgreSQL** – Deploy the database in a private subnet with daily automated backups.
+3. **EC2/Elastic Beanstalk** – Host Node.js API and React frontend using Elastic Beanstalk for simplified scaling.
+4. **S3** – Store uploaded form templates and generated PDFs.
+5. **CloudFront** – Serve static assets via CDN for improved performance.
+6. **Route 53** – Manage DNS records for the custom domain.
+
+## 2. SSL Setup
+1. Request an AWS Certificate Manager (ACM) certificate for the domain.
+2. Attach the certificate to the load balancer on Elastic Beanstalk or the CloudFront distribution.
+3. Enforce HTTPS by redirecting all HTTP requests and enabling HSTS headers.
+
+## 3. Continuous Deployment
+1. Use GitHub Actions to build and deploy on push to the `main` branch.
+2. Configure environment variables in Elastic Beanstalk for database credentials, JWT secret, Stripe keys.
+
+## 4. Backups
+1. Enable automated RDS snapshots with a 7-day retention period.
+2. Nightly backup of S3 buckets using cross-region replication.
+3. Store encrypted dumps of the database in S3 Glacier for long-term retention.
+
+## 5. Monitoring
+1. Enable CloudWatch logs for application servers and configure alarms for error thresholds and high latency.
+2. Use AWS X-Ray or New Relic for tracing API performance.
+3. Set up SNS notifications for deployment events, billing failures, and security alerts.
+
+This setup provides a secure and scalable deployment with reliable backups and ongoing monitoring.

--- a/SAPCO/docs/folder_structure.md
+++ b/SAPCO/docs/folder_structure.md
@@ -1,0 +1,35 @@
+# Folder Structure
+
+```
+SAPCO/
+├── README.md
+├── backend/
+│   ├── server.js
+│   ├── routes/
+│   │   ├── auth.js
+│   │   ├── billing.js
+│   │   └── forms.js
+│   └── models/
+│       ├── user.js
+│       └── auditLog.js
+├── database/
+│   └── schema.sql
+├── docs/
+│   ├── implementation_plan.md
+│   ├── deployment_instructions.md
+│   ├── folder_structure.md
+│   ├── seo_copy_home.md
+│   ├── seo_copy_about.md
+│   ├── seo_copy_subscribe.md
+│   └── seo_copy_legal.md
+└── frontend/
+    ├── css/
+    │   └── styles.css
+    ├── js/
+    │   └── app.js
+    ├── index.html
+    ├── about.html
+    ├── subscribe.html
+    ├── legal.html
+    └── contact.html
+```

--- a/SAPCO/docs/implementation_plan.md
+++ b/SAPCO/docs/implementation_plan.md
@@ -1,0 +1,54 @@
+# Implementation Plan for SAPCO Subscription Website
+
+## 1. Architecture & Technology Stack
+- **Backend:** Node.js with Express for REST API
+- **Frontend:** React (create-react-app) served via Nginx
+- **Database:** PostgreSQL hosted on AWS RDS
+- **Hosting:** AWS Elastic Beanstalk or EC2 for the application servers
+- **Storage:** S3 for document assets
+- **Authentication:** JSON Web Tokens (JWT) with bcrypt password hashing
+- **Billing:** Stripe subscriptions with three tiers (Single Form, Multi Form, Unlimited)
+- **Permissions:** Role-based access control (RBAC) enforced in middleware
+- **Watermarking:** Dynamic 3D watermark overlay on PDFs using `pdf-lib`; user ID and timestamp embedded. Audit logs stored for every download.
+- **Security:** HTTPS (TLS 1.2+), HSTS, Content Security Policy, rate limiting, helmet middleware.
+
+## 2. Major Steps
+1. **Project setup** – Initialize backend and frontend repositories; configure ESLint/Prettier.
+2. **Database schema** – Create tables for users, roles, permissions, forms, subscriptions, audit logs.
+3. **Authentication module** – Implement registration and login endpoints with JWT.
+4. **Subscription billing** – Integrate Stripe, create products/plans, handle webhooks for subscription status.
+5. **Form management** – CRUD APIs for evaluation forms with file upload to S3.
+6. **PDF generation** – Generate filled PDFs on demand; apply 3D watermark from server.
+7. **Audit logging** – Middleware to record user actions (view, download, update) with timestamp/IP.
+8. **Frontend pages** – Build React components for Home, About, Subscribe, Legal, Contact.
+9. **Access control** – Protect routes by role, ensure forms only accessible with valid license count.
+10. **Testing & QA** – Unit and integration tests, security review, performance profiling.
+11. **Deployment** – Provision AWS resources, configure CI/CD, set up domain and SSL.
+12. **Monitoring & Backups** – CloudWatch metrics, daily database snapshots, off-site backups.
+
+## 3. Competitor Analysis
+- **TeachPoint (Vector Solutions):** Offers educator evaluations, multiple form types, robust reporting. Subscription tiers by district size.
+- **TalentEd Perform:** Comprehensive compliance platform for K-12. Tiers based on feature modules and number of administrators.
+- **SchoolMint:** Provides evaluation templates and HR tools with scaling licenses.
+
+SAPCO should mirror this approach by naming tiers:
+1. **Essential** – single evaluation form license.
+2. **Professional** – up to 15 evaluation licenses.
+3. **Enterprise** – unlimited evaluations and priority support.
+
+## 4. Security Considerations
+- Enforce TLS everywhere and redirect HTTP to HTTPS.
+- Implement strong password policies and MFA for administrators.
+- Use Stripe's client-side tokenization to avoid handling raw card data.
+- Use S3 pre-signed URLs for secure, expiring access to files.
+- Disable printing/screenshotting via PDF security settings and custom JavaScript overlays (best-effort; no perfect prevention).
+
+## 5. Milestones & Timeline
+1. Requirements & design – 1 week
+2. MVP backend & database – 2 weeks
+3. Frontend screens & auth – 2 weeks
+4. Billing integration – 1 week
+5. PDF generation with watermark – 1 week
+6. Final QA, deployment, SEO – 1 week
+
+_Total: ~8 weeks for initial launch._

--- a/SAPCO/docs/seo_copy_about.md
+++ b/SAPCO/docs/seo_copy_about.md
@@ -1,0 +1,17 @@
+# About Us Page SEO Copy
+
+**Title tag:** About SAPCO – Trusted Provider of School Administration Forms
+
+**Meta description:** Discover the mission and leadership behind School Administrators Publishing Company. Learn why districts nationwide rely on SAPCO for compliant, fillable evaluation templates.
+
+## Content (350+ words)
+
+**School Administrators Publishing Company (SAPCO)** was founded to solve a pressing problem: how can school leaders maintain consistent documentation that stands up to legal scrutiny? After years working with districts across the country, our founders saw the need for standardized, up-to-date templates tailored to state and federal guidelines. SAPCO launched with a single goal—to provide administrators with the most reliable evaluation forms available.
+
+Our team blends legal expertise with deep experience in K-12 administration. We keep pace with evolving regulations from the U.S. Department of Education, state boards, and the Council of Chief State School Officers. Every template in our library is carefully vetted to ensure accuracy and compliance. We recognize that each district has unique requirements, which is why our platform allows for customizable fields while preserving the legal backbone of each form.
+
+SAPCO is more than a library of documents. We are your partner in ensuring that observations, probationary evaluations, and officer reports are handled with professionalism and care. Our leadership team includes former administrators, legal consultants, and technology specialists dedicated to streamlining your workflow. Together, we deliver a secure, cloud-based system that eliminates paper clutter and reduces administrative risk.
+
+Trust is at the core of our mission. That is why every download and PDF preview features a built-in **3D watermark** and audit-trail capabilities. We maintain strict role-based permissions so only authorized staff can access sensitive data. Schools choose SAPCO because we prioritize confidentiality and compliance without compromising ease of use.
+
+From a single-campus charter to multi-district organizations, SAPCO scales with you. Our subscription tiers—Essential, Professional, and Enterprise—provide flexible options to match your evaluation volume. We invite you to explore our platform, meet our leadership, and see how SAPCO can empower your administrative team.

--- a/SAPCO/docs/seo_copy_home.md
+++ b/SAPCO/docs/seo_copy_home.md
@@ -1,0 +1,19 @@
+# Home Page SEO Copy
+
+**Title tag:** School Administrator Forms – Legal-Safe Evaluation Templates | SAPCO
+
+**Meta description:** Secure, fillable evaluation templates for school administrators. Protect your district with legally compliant forms for observations, probation reviews, and officer reports. Subscribe for single, multi, or unlimited access.
+
+## Content (350+ words)
+
+Welcome to **School Administrators Publishing Company (SAPCO)**—your trusted source for legally compliant evaluation forms. In today’s risk-averse educational environment, administrators must document teacher observations, probationary reviews, and officer reports with absolute precision. SAPCO delivers a robust platform of **fillable online forms** aligned with federal mandates and state codes in Texas, California, and beyond.
+
+Our mission is simple: provide school leaders with the tools they need to conduct evaluations confidently and consistently. Each form is meticulously crafted by legal experts and educational professionals to ensure compliance with the latest standards from the U.S. Department of Education and the Council of Chief State School Officers. With SAPCO, you gain peace of mind that your documentation holds up under scrutiny.
+
+**Why choose SAPCO?** We combine secure, cloud-based technology with intuitive design. Users log in to access a library of up-to-date templates, complete with helpful checklists and contextual guidance. Forms are responsive and mobile-friendly, allowing administrators to conduct walkthroughs on tablets or laptops. When you generate a PDF, the system applies a unique **3D watermark** containing your user ID and timestamp. Audit logs record every view and download, providing an ironclad trail of accountability.
+
+Subscription options are flexible. The **Essential** tier grants access to a single evaluation form—perfect for small schools or pilots. Upgrade to the **Professional** tier for up to 15 evaluations, or unlock unlimited potential with our **Enterprise** plan. Each subscription is managed securely through Stripe, ensuring a smooth checkout and automated renewals.
+
+SAPCO also prioritizes content security. PDFs are encrypted and cannot be printed or copied outside the platform. Combined with strict role-based permissions, this keeps sensitive data in the right hands. Join the growing community of districts that rely on SAPCO for compliance and efficiency.
+
+Ready to simplify your administrative workload? Explore our features, read testimonials from satisfied district leaders, or visit the Subscribe page to compare plans. SAPCO is committed to helping you create a safe, well-documented environment for every educator and student.

--- a/SAPCO/docs/seo_copy_legal.md
+++ b/SAPCO/docs/seo_copy_legal.md
@@ -1,0 +1,23 @@
+# Legal Page SEO Copy
+
+**Title tag:** User Agreement and Licensing Terms | SAPCO
+
+**Meta description:** Review SAPCO’s terms of service, licensing agreement, and nondisclosure obligations. Learn the legal ramifications of unauthorized duplication of our fillable evaluation forms.
+
+## Content (350+ words)
+
+The following User Agreement governs your use of the School Administrators Publishing Company (SAPCO) platform. By accessing SAPCO’s fillable evaluation templates, you accept these terms in full. If you disagree with any part of the agreement, you must not use our services.
+
+### Licensing Terms
+All evaluation templates and related documentation (“Content”) are licensed, not sold, to you by SAPCO. Depending on your subscription tier—Essential, Professional, or Enterprise—you are granted a nonexclusive, nontransferable license to use a specific number of evaluation forms per academic year. You may not reproduce, distribute, or modify the Content outside the SAPCO platform without prior written consent.
+
+### Nondisclosure and Confidentiality
+You acknowledge that SAPCO’s Content, user interface, and underlying technology contain confidential information and trade secrets. You agree to maintain strict confidentiality and to prevent unauthorized disclosure or duplication. Any attempt to reverse engineer, copy, or share the Content with third parties constitutes a breach of this agreement and may result in legal action, including damages and injunctive relief.
+
+### Liability and Indemnification
+SAPCO provides all Content “as is” without warranties of any kind, either expressed or implied. We do not guarantee that the forms will meet every specific state or local requirement. By using the platform, you agree to hold SAPCO harmless from any liability or claims arising from misuse or misinterpretation of the Content. You further agree to indemnify SAPCO for any losses incurred due to your violation of this agreement.
+
+### Audit Trail and Security Measures
+For your protection and ours, each PDF generated within SAPCO includes a dynamic 3D watermark identifying the user and timestamp. All downloads are logged in our secure audit database. Content is restricted from printing or screen capture to the extent allowed by modern browser technology. Unauthorized duplication will trigger immediate termination of your license and potential legal action.
+
+By clicking “I Agree” during registration or subscription checkout, you confirm that you have read and understood these terms. Continued use of SAPCO constitutes acceptance of all conditions herein. If you have questions about our policies, please contact our legal department before proceeding.

--- a/SAPCO/docs/seo_copy_subscribe.md
+++ b/SAPCO/docs/seo_copy_subscribe.md
@@ -1,0 +1,23 @@
+# Subscribe Page SEO Copy
+
+**Title tag:** Pricing – Secure School Evaluation Form Subscriptions | SAPCO
+
+**Meta description:** Choose from Essential, Professional, or Enterprise subscriptions for legal-safe school evaluation forms. Pay securely via Stripe and start documenting with confidence.
+
+## Content (350+ words)
+
+At SAPCO, we understand that every district has unique needs and budget constraints. That’s why we offer three flexible subscription tiers—**Essential**, **Professional**, and **Enterprise**—to ensure you only pay for the level of access you require. Our platform gives school administrators the ability to generate, fill, and securely store evaluation forms that comply with federal guidelines and state mandates from Texas to California.
+
+### Essential
+The Essential plan is perfect for single-campus schools or administrators who need a targeted solution. You receive a license for one evaluation form, complete with our 3D watermark and audit log features. This entry-level tier allows you to explore the SAPCO system and experience the benefits of standardized, legally vetted templates.
+
+### Professional
+Growing districts and charter networks often choose the Professional tier. Here, you unlock up to fifteen evaluation licenses—ideal for managing a larger team while keeping documentation streamlined. With role-based permissions, each evaluator can access only the forms they need. PDF downloads remain protected from printing and copying, and Stripe handles subscription payments with automatic renewal options.
+
+### Enterprise
+Large districts or organizations with complex oversight requirements will appreciate the unlimited nature of the Enterprise plan. Not only do you gain unrestricted access to SAPCO’s entire library of forms, you also receive priority support and customization assistance. Whether you manage dozens or hundreds of evaluations, our audit trail ensures every action is traceable, strengthening your compliance posture.
+
+### Secure Checkout
+All tiers are processed securely through Stripe. Your payment information is encrypted end-to-end, and you can update billing details or cancel anytime through your account portal. We never store raw card data on our servers. After checkout, your subscription status syncs instantly with your SAPCO account, unlocking the appropriate number of evaluation licenses.
+
+Ready to take the next step? Use the buttons below to select your plan and complete the checkout process. If you have questions about which tier fits your needs, our team is here to help. Join the many districts that trust SAPCO for legal-safe evaluation templates and never worry about compliance documentation again.

--- a/SAPCO/frontend/about.html
+++ b/SAPCO/frontend/about.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About SAPCO – Trusted Provider of School Administration Forms</title>
+  <meta name="description" content="Discover the mission and leadership behind SAPCO. Learn why districts rely on our compliant evaluation templates.">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header>
+    <h1>SAPCO</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="subscribe.html">Subscribe</a>
+      <a href="legal.html">Legal</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h2>About Us</h2>
+    <p>SAPCO provides standardized evaluation forms for school administrators. Our mission is to simplify compliance through secure, fillable templates.</p>
+  </main>
+  <footer>
+    <p>&copy; SAPCO</p>
+  </footer>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/SAPCO/frontend/contact.html
+++ b/SAPCO/frontend/contact.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact SAPCO</title>
+  <meta name="description" content="Get in touch with SAPCO for more information or support.">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header>
+    <h1>SAPCO</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="subscribe.html">Subscribe</a>
+      <a href="legal.html">Legal</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h2>Contact Us</h2>
+    <form id="contact-form">
+      <label for="name">Name</label>
+      <input type="text" id="name" name="name" required>
+      <label for="email">Email</label>
+      <input type="email" id="email" name="email" required>
+      <label for="message">Message</label>
+      <textarea id="message" name="message" required></textarea>
+      <button type="submit">Send</button>
+    </form>
+  </main>
+  <footer>
+    <p>&copy; SAPCO</p>
+  </footer>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/SAPCO/frontend/css/styles.css
+++ b/SAPCO/frontend/css/styles.css
@@ -1,0 +1,8 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; line-height: 1.6; }
+header { background: #003366; color: #fff; padding: 10px; }
+nav a { color: #fff; margin-right: 15px; text-decoration: none; }
+main { padding: 20px; }
+footer { background: #f5f5f5; text-align: center; padding: 10px; font-size: 0.9em; }
+.cta { display: inline-block; padding: 10px 20px; background: #007bff; color: #fff; text-decoration: none; }
+.pricing { display: flex; gap: 20px; }
+.tier { border: 1px solid #ccc; padding: 10px; flex: 1; }

--- a/SAPCO/frontend/index.html
+++ b/SAPCO/frontend/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>School Administrator Forms – Legal-Safe Evaluation Templates | SAPCO</title>
+  <meta name="description" content="Secure, fillable evaluation templates for school administrators. Protect your district with legally compliant forms.">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header>
+    <h1>SAPCO</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="subscribe.html">Subscribe</a>
+      <a href="legal.html">Legal</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h2>Trusted School Administrator Forms</h2>
+    <p>Welcome to SAPCO—your source for compliant, fillable evaluation templates. Choose a subscription tier and start documenting with confidence.</p>
+    <a class="cta" href="subscribe.html">View Plans</a>
+  </main>
+  <footer>
+    <p>&copy; SAPCO</p>
+  </footer>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/SAPCO/frontend/js/app.js
+++ b/SAPCO/frontend/js/app.js
@@ -1,0 +1,8 @@
+// Simple handler for pricing buttons
+const buttons = document.querySelectorAll('.tier button');
+buttons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const tier = btn.getAttribute('data-tier');
+    alert(`Selected plan: ${tier}. Integration with Stripe goes here.`);
+  });
+});

--- a/SAPCO/frontend/legal.html
+++ b/SAPCO/frontend/legal.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>User Agreement and Licensing Terms | SAPCO</title>
+  <meta name="description" content="Review SAPCO’s terms of service and licensing agreement.">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header>
+    <h1>SAPCO</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="subscribe.html">Subscribe</a>
+      <a href="legal.html">Legal</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h2>User Agreement</h2>
+    <p>Please review our licensing terms and nondisclosure obligations. Unauthorized duplication is prohibited and may lead to legal action.</p>
+  </main>
+  <footer>
+    <p>&copy; SAPCO</p>
+  </footer>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/SAPCO/frontend/subscribe.html
+++ b/SAPCO/frontend/subscribe.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pricing – Secure School Evaluation Form Subscriptions | SAPCO</title>
+  <meta name="description" content="Choose from Essential, Professional, or Enterprise subscriptions. Pay securely via Stripe.">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header>
+    <h1>SAPCO</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="subscribe.html">Subscribe</a>
+      <a href="legal.html">Legal</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h2>Choose Your Plan</h2>
+    <div class="pricing">
+      <div class="tier">
+        <h3>Essential</h3>
+        <p>Single evaluation form license.</p>
+        <button data-tier="essential">Select</button>
+      </div>
+      <div class="tier">
+        <h3>Professional</h3>
+        <p>Up to 15 evaluations.</p>
+        <button data-tier="professional">Select</button>
+      </div>
+      <div class="tier">
+        <h3>Enterprise</h3>
+        <p>Unlimited evaluations.</p>
+        <button data-tier="enterprise">Select</button>
+      </div>
+    </div>
+  </main>
+  <footer>
+    <p>&copy; SAPCO</p>
+  </footer>
+  <script src="js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add folder with documentation for SAPCO subscription site
- include implementation plan, deployment instructions and SEO copy
- add sample Node.js backend code, database schema and simple HTML/CSS/JS pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68562eb09ff4832f879ba30c74179fd4